### PR TITLE
:rocket: Flutter に依存しない core パッケージを Dart Package 化

### DIFF
--- a/core/common/pubspec.yaml
+++ b/core/common/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/common/test/dummy_test.dart
+++ b/core/common/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/data/pubspec.yaml
+++ b/core/data/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/data/test/dummy_test.dart
+++ b/core/data/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/database/pubspec.yaml
+++ b/core/database/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/database/test/dummy_test.dart
+++ b/core/database/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/datastore/pubspec.yaml
+++ b/core/datastore/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/datastore/test/dummy_test.dart
+++ b/core/datastore/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/domain/pubspec.yaml
+++ b/core/domain/pubspec.yaml
@@ -4,15 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/domain/test/dummy_test.dart
+++ b/core/domain/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/model/pubspec.yaml
+++ b/core/model/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/model/test/dummy_test.dart
+++ b/core/model/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/network/pubspec.yaml
+++ b/core/network/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/network/test/dummy_test.dart
+++ b/core/network/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/core/testing/pubspec.yaml
+++ b/core/testing/pubspec.yaml
@@ -5,15 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: 3.2.4
-  flutter: 3.16.7
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  test: 1.24.0
   yumemi_lints: 1.3.0
-
-flutter:

--- a/core/testing/test/dummy_test.dart
+++ b/core/testing/test/dummy_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('[exampleTest] 1 + 1 = 2', () {

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,6 +18,7 @@ command:
       sdk: 3.2.4
       flutter: 3.16.7
     dev_dependencies:
+      test: 1.24.0
       yumemi_lints: 1.3.0
 
 scripts:

--- a/melos.yaml
+++ b/melos.yaml
@@ -74,7 +74,18 @@ scripts:
 
   test:
     run: |
-      melos exec -c 10 --fail-fast -- flutter test --coverage
+      melos run test:dart --no-select && melos run test:flutter --no-select
+    description: Run flutter test.
+  test:dart:
+    run: |
+      melos exec -c 10 --fail-fast -- "dart test"
+    description: Run Dart test.
+    packageFilters:
+      flutter: false
+      dirExists: test
+  test:flutter:
+    run: |
+      melos exec -c 10 --fail-fast -- "flutter test --coverage"
     description: Run flutter test.
     packageFilters:
       flutter: true


### PR DESCRIPTION
## Issue

- close #5 🦕

## 概要

<!-- 概要をここに記入してください。 -->

表題の通り, 不要な Flutter 依存を削除して Dart Package 化します.

以下のパッケージを対象とします.

- common
- data
- database
- datastore
- domain
- model
- network
- testing

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

- designsystem, ui パッケージが Fltuter Package のままであることをご確認いただきたいです
- 変更を最小限にしているつもりですが, 過不足がないかご確認いただきたいです
- test のバージョンを 1.24.0 と少し古めにしていますが, Dependabot の動作検証のためでレビューの対象外とさせてください 🙏

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://pub.dev/packages/test

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |