### PR TITLE
build: Android の minSdk を 30 に設定

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "quest.asis.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 30 // Android 11
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -28,12 +28,11 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
-
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

古いバージョンに対応しているとサポートが大変, セキュリティ的に脆弱なため Android の minSdk を 30(Android 11) に設定します.
Android 11 からは Java 11 にシステムが対応しているため, 併せて `compileOptions` も `JavaVersion.VERSION_11` に設定します.

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://developer.android.com/build/jdks#compileSdk

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- AndroidアプリのJavaとKotlinの互換性設定を更新しました。Javaのソースとターゲットの互換性をバージョン1.8から11に、KotlinのJVMターゲットを1.8から11に変更しました。また、最小SDKバージョンをAndroid 11の30に明示的に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->