### PR TITLE
refactor: Firebase.initializeAppの引数でFlavor(Enum)を使用する

### DIFF
--- a/app/lib/app_initializer.dart
+++ b/app/lib/app_initializer.dart
@@ -18,7 +18,7 @@ final class AppInitializer {
 
     final buildConfig = await _initializeBuildConfig();
     await _initializeDatabase();
-    await _initializeFirebase();
+    await _initializeFirebase(buildConfig: buildConfig);
 
     return buildConfig;
   }
@@ -45,14 +45,15 @@ final class AppInitializer {
     await Database.initialize();
   }
 
-  static Future<void> _initializeFirebase() async {
+  static Future<void> _initializeFirebase({
+    required BuildConfig buildConfig,
+  }) async {
     await Firebase.initializeApp(
       /// MEMO(@chippy-ao): 後々、環境によってFirebaseOptionsを切り替える
-      options: switch (appFlavor) {
-        'dev' => dev.AppFirebaseOptions.currentPlatform,
-        'stg' => dev.AppFirebaseOptions.currentPlatform,
-        'prod' => dev.AppFirebaseOptions.currentPlatform,
-        _ => throw UnsupportedError('Unsupported flavor: $appFlavor'),
+      options: switch (buildConfig.flavor) {
+        Flavor.dev => dev.AppFirebaseOptions.currentPlatform,
+        Flavor.stg => dev.AppFirebaseOptions.currentPlatform,
+        Flavor.prod => dev.AppFirebaseOptions.currentPlatform,
       },
     );
   }

--- a/app/lib/app_initializer.dart
+++ b/app/lib/app_initializer.dart
@@ -18,7 +18,7 @@ final class AppInitializer {
 
     final buildConfig = await _initializeBuildConfig();
     await _initializeDatabase();
-    await _initializeFirebase(buildConfig: buildConfig);
+    await _initializeFirebase(flavor: buildConfig.flavor);
 
     return buildConfig;
   }

--- a/app/lib/app_initializer.dart
+++ b/app/lib/app_initializer.dart
@@ -46,7 +46,7 @@ final class AppInitializer {
   }
 
   static Future<void> _initializeFirebase({
-    required BuildConfig buildConfig,
+    required Flavor flavor,
   }) async {
     await Firebase.initializeApp(
       /// MEMO(@chippy-ao): 後々、環境によってFirebaseOptionsを切り替える

--- a/app/lib/app_initializer.dart
+++ b/app/lib/app_initializer.dart
@@ -50,7 +50,7 @@ final class AppInitializer {
   }) async {
     await Firebase.initializeApp(
       /// MEMO(@chippy-ao): 後々、環境によってFirebaseOptionsを切り替える
-      options: switch (buildConfig.flavor) {
+      options: switch (flavor) {
         Flavor.dev => dev.AppFirebaseOptions.currentPlatform,
         Flavor.stg => dev.AppFirebaseOptions.currentPlatform,
         Flavor.prod => dev.AppFirebaseOptions.currentPlatform,


### PR DESCRIPTION
## Issue

- close #120 

## 概要

<!-- 概要をここに記入してください。 -->

- buildConfigのFlavorを使用して、無駄なSwitch分岐を減らしました。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Firebaseの初期化ロジックが更新され、`Flavor`パラメータを使用するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->