### PR TITLE
fix(catalog): 設定画面を表示できるように修正

### DIFF
--- a/catalog/lib/main.dart
+++ b/catalog/lib/main.dart
@@ -1,6 +1,15 @@
 import 'package:catalog/widgetbook.dart';
+import 'package:core_model/build_config.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
-  runApp(const WidgetbookApp());
+  runApp(
+    ProviderScope(
+      overrides: [
+        buildConfigProvider.overrideWithValue(FakeBuildConfig()),
+      ],
+      child: const WidgetbookApp(),
+    ),
+  );
 }

--- a/catalog/pubspec.lock
+++ b/catalog/pubspec.lock
@@ -204,7 +204,7 @@ packages:
     source: path
     version: "0.0.0"
   core_model:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../core/model"
       relative: true
@@ -346,7 +346,7 @@ packages:
     source: hosted
     version: "0.20.5"
   flutter_riverpod:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_riverpod
       sha256: "4bce556b7ecbfea26109638d5237684538d4abc509d253e6c5c4c5733b360098"

--- a/catalog/pubspec.yaml
+++ b/catalog/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   core_designsystem:
     # noinspection DartPathPackageReference
     path: ../core/designsystem
+  core_model:
+    # noinspection DartPathPackageReference
+    path: ../core/model
   cupertino_icons: 1.0.6
   dynamic_color: 1.6.9
   feature_auth:
@@ -26,6 +29,7 @@ dependencies:
     path: ../feature/settings
   flutter:
     sdk: flutter
+  flutter_riverpod: 2.4.10
   widgetbook: 3.7.1
   widgetbook_annotation: 3.1.0
 

--- a/core/model/lib/src/build_config/build_config.dart
+++ b/core/model/lib/src/build_config/build_config.dart
@@ -17,3 +17,20 @@ abstract interface class BuildConfig {
   abstract final Flavor flavor;
   abstract final String? installerStore;
 }
+
+final class FakeBuildConfig implements BuildConfig {
+  @override
+  final String appName = 'Fake App';
+  @override
+  final String packageName = 'com.example.fake_app';
+  @override
+  final String version = '1.0.0';
+  @override
+  final String buildNumber = '1';
+  @override
+  final String buildSignature = '1';
+  @override
+  final Flavor flavor = Flavor.dev;
+  @override
+  final String? installerStore = 'fake_store';
+}

--- a/core/model/lib/src/build_config/index.dart
+++ b/core/model/lib/src/build_config/index.dart
@@ -1,2 +1,3 @@
-export 'build_config.dart' show BuildConfig, buildConfigProvider;
+export 'build_config.dart'
+    show BuildConfig, FakeBuildConfig, buildConfigProvider;
 export 'flavor.dart';


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

設定画面を表示できるように修正します.

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アプリの設定を管理するために`flutter_riverpod`を使用し、`FakeBuildConfig`を介して`buildConfigProvider`のオーバーライドを導入しました。
	- 新しい依存関係`core_model`を追加し、`flutter_riverpod`のバージョンを2.4.10に更新しました。
	- 様々なプロパティを持つ`FakeBuildConfig`クラスを追加し、アプリの設定を模擬する機能を強化しました。

- **依存性の変更**
	- `core_model`と`flutter_riverpod`の依存関係が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->