### PR TITLE
[GH-250] ライセンスページへの遷移を rootNavigatorKey に変更

### DIFF
--- a/app/lib/router/go_route/settings_route.dart
+++ b/app/lib/router/go_route/settings_route.dart
@@ -1,3 +1,4 @@
+import 'package:asis_app/router/app_navigation_key.dart';
 import 'package:asis_app/router/app_page_path.dart';
 import 'package:asis_app/router/shell_route/app_shell_route.dart';
 import 'package:feature_settings/feature_settings.dart';
@@ -31,4 +32,6 @@ final class SettingsRoute extends SettingsRouteData {
 /// ライセンスページへのルート
 final class LicenseRoute extends LicenseRouteData {
   const LicenseRoute();
+
+  static final $parentNavigatorKey = rootNavigatorKey;
 }

--- a/app/lib/router/shell_route/app_shell_route.g.dart
+++ b/app/lib/router/shell_route/app_shell_route.g.dart
@@ -47,6 +47,7 @@ RouteBase get $appShellRouteData => StatefulShellRouteData.$route(
               routes: [
                 GoRouteData.$route(
                   path: 'license',
+                  parentNavigatorKey: LicenseRoute.$parentNavigatorKey,
                   factory: $LicenseRouteExtension._fromState,
                 ),
               ],


### PR DESCRIPTION
## Issue

- close #250 🦕

## 概要

<!-- 概要をここに記入してください。 -->

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

ライセンスページへの遷移を rootNavigatorKey に変更します．

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |