### PR TITLE
[GH-335] changes ジョブを別ファイルに切り分け

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,42 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changed:
+  changes:
+    uses: ./.github/workflows/wc-changes.yml
+
+  action:
     runs-on: ubuntu-22.04
+    needs: changes
+    if: needs.changes.outputs.action == 'true'
     permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      action: ${{ steps.changes.outputs.action }}
-      all: ${{ steps.changes.outputs.all }}
-      any: ${{ steps.changes.outputs.changes != '[]' }}
+      checks: "write"
+      contents: "read"
+      pull-requests: "write"
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      # https://github.com/marketplace/actions/paths-changes-filter
-      - name: Paths Changes Filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
+      # https://github.com/marketplace/actions/actionlint-with-reviewdog
+      - uses: reviewdog/action-actionlint@4797143fa54b2306fe78646b48cfa10395506635 # v1.47.0
         with:
-          filters: |
-            action:
-              - '.github/workflows/*.yml'
-            all:
-              - '.github/workflows/checks.yml'
-              - '.tool-versions'
-              - 'melos.yaml'
-              - 'app/**/*'
-              - 'core/**/lib/**/*'
-              - 'feature/**/lib/**/*'
-              - '**/pubspec.lock'
-              - '**/pubspec.yaml'
+          fail_on_error: true
+          filter_mode: nofilter
+          level: error
+          reporter: github-pr-review
 
   cache-deps:
     runs-on: ubuntu-22.04
-    needs: changed
-    if: needs.changed.outputs.all == 'true'
+    needs: changes
+    if: needs.changes.outputs.dependencies == 'true'
     timeout-minutes: 10
 
     steps:
@@ -85,9 +77,9 @@ jobs:
   analyze:
     runs-on: ubuntu-22.04
     needs:
-      - changed
+      - changes
       - cache-deps
-    if: needs.changed.outputs.all == 'true'
+    if: needs.changes.outputs.analyze == 'true'
     timeout-minutes: 10
 
     steps:
@@ -130,9 +122,9 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     needs:
-      - changed
+      - changes
       - cache-deps
-    if: needs.changed.outputs.all == 'true'
+    if: needs.changes.outputs.test == 'true'
     timeout-minutes: 10
 
     steps:
@@ -175,33 +167,12 @@ jobs:
       - name: Run test
         run: melos run ci:test --no-select
 
-  check-action:
-    runs-on: ubuntu-22.04
-    needs: changed
-    if: needs.changed.outputs.action == 'true'
-    permissions:
-      checks: "write"
-      contents: "read"
-      pull-requests: "write"
-    steps:
-      # https://github.com/marketplace/actions/checkout
-      - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
-      # https://github.com/marketplace/actions/actionlint-with-reviewdog
-      - uses: reviewdog/action-actionlint@4797143fa54b2306fe78646b48cfa10395506635 # v1.47.0
-        with:
-          fail_on_error: true
-          filter_mode: nofilter
-          level: error
-          reporter: github-pr-review
-
   status-check:
     runs-on: ubuntu-22.04
     needs:
       - analyze
       - test
-      - check-action
+      - action
     permissions: { }
     if: failure()
     steps:

--- a/.github/workflows/wc-changes.yml
+++ b/.github/workflows/wc-changes.yml
@@ -1,0 +1,75 @@
+name: "Check for changes in paths"
+
+on:
+  workflow_call:
+    outputs:
+      action:
+        value: ${{ jobs.changes.outputs.action }}
+      analyze:
+        value: ${{ jobs.changes.outputs.analyze }}
+      any:
+        value: ${{ jobs.changes.outputs.any }}
+      test:
+        value: ${{ jobs.changes.outputs.test }}
+      dependencies:
+        value: ${{ jobs.changes.outputs.dependencies }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      action: ${{ steps.filter.outputs.action }}
+      analyze: ${{ steps.filter.outputs.analyze }}
+      any: ${{ steps.filter.outputs.changes != '[]' }}
+      test: ${{ steps.filter.outputs.test }}
+      dependencies: ${{ steps.needs.outputs.dependencies }}
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      # https://github.com/marketplace/actions/paths-changes-filter
+      - name: Paths Changes Filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            action:
+              - '.github/actions/*.yml'
+              - '.github/workflows/*.yml'
+            analyze:
+              - '.github/workflows/checks.yml'
+              - '.github/workflows/wc-changed.yml'
+              - '.tool-versions'
+              - 'melos.yaml'
+              - 'app/**/*'
+              - 'core/**/lib/**/*'
+              - 'feature/**/lib/**/*'
+              - '**/pubspec.*'
+            test:
+              - '.github/workflows/checks.yml'
+              - '.github/workflows/wc-changed.yml'
+              - '.tool-versions'
+              - 'melos.yaml'
+              - 'app/**/*'
+              - 'core/**/lib/**/*'
+              - 'feature/**/lib/**/*'
+              - '**/pubspec.*'
+
+      - name: Check for dependencies changes
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: needs
+        with:
+          script: |
+            const changes = ${{ steps.filter.outputs.changes }};
+            
+            // 依存関係の解決が必要な変更箇所
+            const dependencies = [
+              'analyze',
+              'test',
+            ];
+            core.setOutput('dependencies', changes.some(value => dependencies.includes(value)));


### PR DESCRIPTION
## Issue

- close #335 🦕

## 概要

<!-- 概要をここに記入してください。 -->

changes ジョブを別ファイルに切り分けます．

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Renamed and updated job dependencies and conditions in the GitHub Actions workflow for better integration.
  - Added a new workflow to check for changes in specified paths and filter actions accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->