### PR TITLE
[GH-355] Get 系以外の UseCase を Raw に変更

### DIFF
--- a/core/domain/lib/src/use_case/auth/sign_in_use_case.dart
+++ b/core/domain/lib/src/use_case/auth/sign_in_use_case.dart
@@ -5,7 +5,7 @@ part 'sign_in_use_case.g.dart';
 
 /// サインインする ユースケース
 @riverpod
-Future<void> signInUseCase(
+Raw<Future<void>> signInUseCase(
   SignInUseCaseRef ref, {
   required String email,
   required String password,

--- a/core/domain/lib/src/use_case/auth/sign_in_use_case.g.dart
+++ b/core/domain/lib/src/use_case/auth/sign_in_use_case.g.dart
@@ -6,7 +6,7 @@ part of 'sign_in_use_case.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$signInUseCaseHash() => r'be6ccbe76d6f291511ddce735b66b8ee0b3dce1b';
+String _$signInUseCaseHash() => r'1441b2e214d6c3d296ef67fc07b6bff559856891';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -38,7 +38,7 @@ const signInUseCaseProvider = SignInUseCaseFamily();
 /// サインインする ユースケース
 ///
 /// Copied from [signInUseCase].
-class SignInUseCaseFamily extends Family<AsyncValue<void>> {
+class SignInUseCaseFamily extends Family<Raw<Future<void>>> {
   /// サインインする ユースケース
   ///
   /// Copied from [signInUseCase].
@@ -85,7 +85,7 @@ class SignInUseCaseFamily extends Family<AsyncValue<void>> {
 /// サインインする ユースケース
 ///
 /// Copied from [signInUseCase].
-class SignInUseCaseProvider extends AutoDisposeFutureProvider<void> {
+class SignInUseCaseProvider extends AutoDisposeProvider<Raw<Future<void>>> {
   /// サインインする ユースケース
   ///
   /// Copied from [signInUseCase].
@@ -127,7 +127,7 @@ class SignInUseCaseProvider extends AutoDisposeFutureProvider<void> {
 
   @override
   Override overrideWith(
-    FutureOr<void> Function(SignInUseCaseRef provider) create,
+    Raw<Future<void>> Function(SignInUseCaseRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -145,7 +145,7 @@ class SignInUseCaseProvider extends AutoDisposeFutureProvider<void> {
   }
 
   @override
-  AutoDisposeFutureProviderElement<void> createElement() {
+  AutoDisposeProviderElement<Raw<Future<void>>> createElement() {
     return _SignInUseCaseProviderElement(this);
   }
 
@@ -166,7 +166,7 @@ class SignInUseCaseProvider extends AutoDisposeFutureProvider<void> {
   }
 }
 
-mixin SignInUseCaseRef on AutoDisposeFutureProviderRef<void> {
+mixin SignInUseCaseRef on AutoDisposeProviderRef<Raw<Future<void>>> {
   /// The parameter `email` of this provider.
   String get email;
 
@@ -175,7 +175,8 @@ mixin SignInUseCaseRef on AutoDisposeFutureProviderRef<void> {
 }
 
 class _SignInUseCaseProviderElement
-    extends AutoDisposeFutureProviderElement<void> with SignInUseCaseRef {
+    extends AutoDisposeProviderElement<Raw<Future<void>>>
+    with SignInUseCaseRef {
   _SignInUseCaseProviderElement(super.provider);
 
   @override

--- a/core/domain/lib/src/use_case/auth/sign_out_use_case.dart
+++ b/core/domain/lib/src/use_case/auth/sign_out_use_case.dart
@@ -5,5 +5,5 @@ part 'sign_out_use_case.g.dart';
 
 /// サインアウトする ユースケース
 @riverpod
-Future<void> signOutUseCase(SignOutUseCaseRef ref) async =>
+Raw<Future<void>> signOutUseCase(SignOutUseCaseRef ref) async =>
     ref.watch(authenticatorProvider).signOut();

--- a/core/domain/lib/src/use_case/auth/sign_out_use_case.g.dart
+++ b/core/domain/lib/src/use_case/auth/sign_out_use_case.g.dart
@@ -6,13 +6,13 @@ part of 'sign_out_use_case.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$signOutUseCaseHash() => r'a4b4b9a994cc4d9ad03e7a74ddc32ad28a987c10';
+String _$signOutUseCaseHash() => r'd879f626219936be5ce6a6ac93ee02f64facb37c';
 
 /// サインアウトする ユースケース
 ///
 /// Copied from [signOutUseCase].
 @ProviderFor(signOutUseCase)
-final signOutUseCaseProvider = AutoDisposeFutureProvider<void>.internal(
+final signOutUseCaseProvider = AutoDisposeProvider<Raw<Future<void>>>.internal(
   signOutUseCase,
   name: r'signOutUseCaseProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -22,6 +22,6 @@ final signOutUseCaseProvider = AutoDisposeFutureProvider<void>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef SignOutUseCaseRef = AutoDisposeFutureProviderRef<void>;
+typedef SignOutUseCaseRef = AutoDisposeProviderRef<Raw<Future<void>>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/core/domain/lib/src/use_case/quest/add_quest_use_case.dart
+++ b/core/domain/lib/src/use_case/quest/add_quest_use_case.dart
@@ -6,7 +6,7 @@ part 'add_quest_use_case.g.dart';
 
 /// クエストを追加する ユースケース
 @riverpod
-Future<void> addQuestUseCase(
+Raw<Future<void>> addQuestUseCase(
   AddQuestUseCaseRef ref, {
   required Quest quest,
 }) =>

--- a/core/domain/lib/src/use_case/quest/add_quest_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/add_quest_use_case.g.dart
@@ -6,7 +6,7 @@ part of 'add_quest_use_case.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$addQuestUseCaseHash() => r'7b608aa709a533daff5982adeec33807c58d9cb4';
+String _$addQuestUseCaseHash() => r'390015092f007e1c39cdc849024a96037976a932';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -38,7 +38,7 @@ const addQuestUseCaseProvider = AddQuestUseCaseFamily();
 /// クエストを追加する ユースケース
 ///
 /// Copied from [addQuestUseCase].
-class AddQuestUseCaseFamily extends Family<AsyncValue<void>> {
+class AddQuestUseCaseFamily extends Family<Raw<Future<void>>> {
   /// クエストを追加する ユースケース
   ///
   /// Copied from [addQuestUseCase].
@@ -82,7 +82,7 @@ class AddQuestUseCaseFamily extends Family<AsyncValue<void>> {
 /// クエストを追加する ユースケース
 ///
 /// Copied from [addQuestUseCase].
-class AddQuestUseCaseProvider extends AutoDisposeFutureProvider<void> {
+class AddQuestUseCaseProvider extends AutoDisposeProvider<Raw<Future<void>>> {
   /// クエストを追加する ユースケース
   ///
   /// Copied from [addQuestUseCase].
@@ -119,7 +119,7 @@ class AddQuestUseCaseProvider extends AutoDisposeFutureProvider<void> {
 
   @override
   Override overrideWith(
-    FutureOr<void> Function(AddQuestUseCaseRef provider) create,
+    Raw<Future<void>> Function(AddQuestUseCaseRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -136,7 +136,7 @@ class AddQuestUseCaseProvider extends AutoDisposeFutureProvider<void> {
   }
 
   @override
-  AutoDisposeFutureProviderElement<void> createElement() {
+  AutoDisposeProviderElement<Raw<Future<void>>> createElement() {
     return _AddQuestUseCaseProviderElement(this);
   }
 
@@ -154,13 +154,14 @@ class AddQuestUseCaseProvider extends AutoDisposeFutureProvider<void> {
   }
 }
 
-mixin AddQuestUseCaseRef on AutoDisposeFutureProviderRef<void> {
+mixin AddQuestUseCaseRef on AutoDisposeProviderRef<Raw<Future<void>>> {
   /// The parameter `quest` of this provider.
   Quest get quest;
 }
 
 class _AddQuestUseCaseProviderElement
-    extends AutoDisposeFutureProviderElement<void> with AddQuestUseCaseRef {
+    extends AutoDisposeProviderElement<Raw<Future<void>>>
+    with AddQuestUseCaseRef {
   _AddQuestUseCaseProviderElement(super.provider);
 
   @override

--- a/core/domain/lib/src/use_case/user_settings/update_theme_use_case.dart
+++ b/core/domain/lib/src/use_case/user_settings/update_theme_use_case.dart
@@ -6,7 +6,7 @@ part 'update_theme_use_case.g.dart';
 
 /// テーマ設定を更新する ユースケース
 @riverpod
-Future<bool> updateThemeUseCase(
+Raw<Future<void>> updateThemeUseCase(
   UpdateThemeUseCaseRef ref, {
   required Theme theme,
 }) =>

--- a/core/domain/lib/src/use_case/user_settings/update_theme_use_case.g.dart
+++ b/core/domain/lib/src/use_case/user_settings/update_theme_use_case.g.dart
@@ -7,7 +7,7 @@ part of 'update_theme_use_case.dart';
 // **************************************************************************
 
 String _$updateThemeUseCaseHash() =>
-    r'875cd819f0ac58c5440808e0fcd9e9b6fc642479';
+    r'15743c202dada7bd25f2e4289d498291ffad0db0';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -39,7 +39,7 @@ const updateThemeUseCaseProvider = UpdateThemeUseCaseFamily();
 /// テーマ設定を更新する ユースケース
 ///
 /// Copied from [updateThemeUseCase].
-class UpdateThemeUseCaseFamily extends Family<AsyncValue<bool>> {
+class UpdateThemeUseCaseFamily extends Family<Raw<Future<void>>> {
   /// テーマ設定を更新する ユースケース
   ///
   /// Copied from [updateThemeUseCase].
@@ -83,7 +83,8 @@ class UpdateThemeUseCaseFamily extends Family<AsyncValue<bool>> {
 /// テーマ設定を更新する ユースケース
 ///
 /// Copied from [updateThemeUseCase].
-class UpdateThemeUseCaseProvider extends AutoDisposeFutureProvider<bool> {
+class UpdateThemeUseCaseProvider
+    extends AutoDisposeProvider<Raw<Future<void>>> {
   /// テーマ設定を更新する ユースケース
   ///
   /// Copied from [updateThemeUseCase].
@@ -120,7 +121,7 @@ class UpdateThemeUseCaseProvider extends AutoDisposeFutureProvider<bool> {
 
   @override
   Override overrideWith(
-    FutureOr<bool> Function(UpdateThemeUseCaseRef provider) create,
+    Raw<Future<void>> Function(UpdateThemeUseCaseRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -137,7 +138,7 @@ class UpdateThemeUseCaseProvider extends AutoDisposeFutureProvider<bool> {
   }
 
   @override
-  AutoDisposeFutureProviderElement<bool> createElement() {
+  AutoDisposeProviderElement<Raw<Future<void>>> createElement() {
     return _UpdateThemeUseCaseProviderElement(this);
   }
 
@@ -155,13 +156,14 @@ class UpdateThemeUseCaseProvider extends AutoDisposeFutureProvider<bool> {
   }
 }
 
-mixin UpdateThemeUseCaseRef on AutoDisposeFutureProviderRef<bool> {
+mixin UpdateThemeUseCaseRef on AutoDisposeProviderRef<Raw<Future<void>>> {
   /// The parameter `theme` of this provider.
   Theme get theme;
 }
 
 class _UpdateThemeUseCaseProviderElement
-    extends AutoDisposeFutureProviderElement<bool> with UpdateThemeUseCaseRef {
+    extends AutoDisposeProviderElement<Raw<Future<void>>>
+    with UpdateThemeUseCaseRef {
   _UpdateThemeUseCaseProviderElement(super.provider);
 
   @override

--- a/core/domain/test/use_case/auth/sign_in_use_case_test.dart
+++ b/core/domain/test/use_case/auth/sign_in_use_case_test.dart
@@ -27,7 +27,7 @@ void main() {
         signInUseCaseProvider(
           email: 'test@example.com',
           password: 'password123',
-        ).future,
+        ),
       );
 
       verify(

--- a/feature/auth/lib/src/ui/page/auth/components/sign_in_form.dart
+++ b/feature/auth/lib/src/ui/page/auth/components/sign_in_form.dart
@@ -86,7 +86,7 @@ final class SignInForm extends HookConsumerWidget {
                           signInUseCaseProvider(
                             email: emailValue.text,
                             password: passwordValue.text,
-                          ).future,
+                          ),
                         );
                         _onLoginSuccess();
                       },

--- a/feature/quest/lib/src/ui/page/add/quest_add_page_state_machine.dart
+++ b/feature/quest/lib/src/ui/page/add/quest_add_page_state_machine.dart
@@ -17,7 +17,7 @@ class QuestAddPageStateMachine extends _$QuestAddPageStateMachine {
   Future<void> dispatch(QuestAddPageAction action) async {
     switch (action) {
       case AddQuestButtonTapped(:final quest):
-        ref.read(addQuestUseCaseProvider(quest: quest));
+        await ref.read(addQuestUseCaseProvider(quest: quest));
     }
   }
 }

--- a/feature/settings/lib/src/ui/page/settings/settings_page.dart
+++ b/feature/settings/lib/src/ui/page/settings/settings_page.dart
@@ -47,7 +47,7 @@ final class SettingsPage extends ConsumerWidget {
             ),
             title: const Text('サインアウト'),
             onTap: () async {
-              await ref.read(signOutUseCaseProvider.future);
+              await ref.read(signOutUseCaseProvider);
               _onSignOutSuccess();
             },
           ),

--- a/feature/settings/lib/src/ui/page/settings/theme_setting_dialog_page.dart
+++ b/feature/settings/lib/src/ui/page/settings/theme_setting_dialog_page.dart
@@ -50,7 +50,7 @@ final class ThemeSettingDialogPage extends HookConsumerWidget {
         ),
         TextButton(
           onPressed: () async {
-            ref.read(
+            await ref.read(
               updateThemeUseCaseProvider(theme: selectedTheme.value),
             );
             _onTapPositive();


### PR DESCRIPTION
## Issue

- close #355 

## 概要

<!-- 概要をここに記入してください。 -->

- 利用側が `await` などを実行できるよう、`AsyncValue` から `Raw` へ変更しました。

## レビュー観点

- ~~エラーとなった箇所は合わせて修正していますが、別途、利用側で `await` が付けたかったみたいな部分があれば、入れ込もうと思いますので、よろしくです（特に投げっぱなしでよければ問題なしです）。~~
- analyzer の指摘で、使用箇所には `await` を付けてます。
  - 投げっぱなしがよかった場合、おそらく `StateMachine` で `Future<void>` ではなく、 `void` でメソッドを作る必要があります（ここで直してもいいし、別Issueでも大丈夫です）。
  - 「あ、ここ `await` 付けちゃったのね」という把握の観点でさぁーっと見ておいてもらえればと思います。

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://github.com/tatsutakein-jp/asis-app/discussions/354

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated return types for various use cases to improve consistency and reliability.
  - Modified provider classes and method signatures to align with new return types.
  - Adjusted test cases and UI components to reflect changes in provider calls.

- **Bug Fixes**
  - Improved asynchronous handling in theme settings and quest addition functionalities.

These changes aim to enhance the robustness and maintainability of the application while ensuring smooth user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->