### PR TITLE
[GH-374] ci: type ラベルのカイゼン

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,47 +4,47 @@ version: 1
 labels:
   # Type labels
   - label: "@type/feature"
-    title: '^feature(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*feat(?:\(.+?\))?\!?:'
 
   - label: "@type/fix"
-    title: '^fix(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*fix(?:\(.+?\))?\!?:'
 
   - label: "@type/docs"
-    title: '^docs(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*docs(?:\(.+?\))?\!?:'
     files:
       - "docs/.+"
       - "**/README.md$"
 
   - label: "@type/style"
-    title: '^style(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*style(?:\(.+?\))?\!?:'
 
   - label: "@type/refactor"
-    title: '^refactor(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*refactor(?:\(.+?\))?\!?:'
 
   - label: "@type/perf"
-    title: '^perf(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*perf(?:\(.+?\))?\!?:'
 
   - label: "@type/test"
-    title: '^test(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*test(?:\(.+?\))?\!?:'
 
   - label: "@type/build"
-    title: '^build(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*build(?:\(.+?\))?\!?:'
     files:
       - "**/pubspec.yaml$"
       - "**/melos.yaml$"
 
   - label: "@type/ci"
-    title: '^ci(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*ci(?:\(.+?\))?\!?:'
     files:
       - '\.github/.+'
       - "scripts/.+"
       - "tools/.+"
 
   - label: "@type/chore"
-    title: '^chore(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*chore(?:\(.+?\))?\!?:'
 
   - label: "@type/revert"
-    title: '^revert(?:\(.+\))?\!?:'
+    title: '^\[.*?\]\s*revert(?:\(.+?\))?\!?:'
 
   # App Package labels
   - label: "@application"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,30 @@ version: 1
 
 labels:
   # Type labels
+  - label: "@type/feature"
+    title: '^feature(?:\(.+\))?\!?:'
+
+  - label: "@type/fix"
+    title: '^fix(?:\(.+\))?\!?:'
+
+  - label: "@type/docs"
+    title: '^docs(?:\(.+\))?\!?:'
+    files:
+      - "docs/.+"
+      - "**/README.md$"
+
+  - label: "@type/style"
+    title: '^style(?:\(.+\))?\!?:'
+
+  - label: "@type/refactor"
+    title: '^refactor(?:\(.+\))?\!?:'
+
+  - label: "@type/perf"
+    title: '^perf(?:\(.+\))?\!?:'
+
+  - label: "@type/test"
+    title: '^test(?:\(.+\))?\!?:'
+
   - label: "@type/build"
     title: '^build(?:\(.+\))?\!?:'
     files:
@@ -16,20 +40,11 @@ labels:
       - "scripts/.+"
       - "tools/.+"
 
-  - label: "@type/docs"
-    title: '^docs:(?:\(.+\))?\!?:'
-    files:
-      - "docs/.+"
-      - "**/README.md$"
+  - label: "@type/chore"
+    title: '^chore(?:\(.+\))?\!?:'
 
-  - label: "@type/feature"
-    title: '^feat:(?:\(.+\))?\!?:'
-
-  - label: "@type/fix"
-    title: '^fix:(?:\(.+\))?\!?:'
-
-  - label: "@type/improve"
-    title: '^(style|refactor|perf)(?:\(.+\))?\!?:'
+  - label: "@type/revert"
+    title: '^revert(?:\(.+\))?\!?:'
 
   # App Package labels
   - label: "@application"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,10 +10,6 @@
 - name: "DO NOT MERGE"
   color: "b60205"
 
-- name: "documentation"
-  color: "0075ca"
-  description: "Improvements or additions to documentation"
-
 - name: "duplicate"
   color: "cfd8d7"
   description: "This issue or pull request already exists"
@@ -42,24 +38,50 @@
   color: "e5d19e"
 
 # Type labels
-- name: "@type/build"
-  color: "ededed"
-
-- name: "@type/ci"
-  color: "ededed"
-
-- name: "@type/docs"
-  color: "ededed"
-  from_name: "documentation"
-
 - name: "@type/feature"
   color: "ededed"
+  description: "A new feature"
 
 - name: "@type/fix"
   color: "ededed"
+  description: "A bug fix"
 
-- name: "@type/improve"
+- name: "@type/docs"
   color: "ededed"
+  description: "Documentation only changes"
+  from_name: "documentation"
+
+- name: "@type/style"
+  color: "f4930e"
+  description: "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+
+- name: "@type/refactor"
+  color: "bfcbed"
+  description: "A code change that neither fixes a bug nor adds a feature"
+
+- name: "@type/perf"
+  color: "2aaf69"
+  description: "A code change that improves performance"
+
+- name: "@type/test"
+  color: "6df5d2"
+  description: "Adding missing tests or correcting existing tests"
+
+- name: "@type/build"
+  color: "ededed"
+  description: "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+
+- name: "@type/ci"
+  color: "ededed"
+  description: "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+
+- name: "@type/chore"
+  color: "f968e0"
+  description: "Other changes that don't modify src or test files"
+
+- name: "@type/revert"
+  color: "4f790d"
+  description: "Reverts a previous commit"
 
 # App Package labels
 - name: "@application"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,58 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - 'ignore for release'
+
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - 'breaking change'
+
+    - title: ✨ Features
+      labels:
+        - '@type/feature'
+
+    - title: 🐛 Bug Fixes
+      labels:
+        - '@type/fix'
+
+    - title: 📚 Documentation
+      labels:
+        - '@type/docs'
+
+    - title: 💎 Styles
+      labels:
+        - '@type/style'
+
+    - title: 📦 Code Refactoring
+      labels:
+        - '@type/refactor'
+
+    - title: 🚀 Performance Improvements
+      labels:
+        - '@type/perf'
+
+    - title: 🚨 Tests
+      labels:
+        - '@type/test'
+
+    - title: 🛠 Builds
+      labels:
+        - '@type/build'
+
+    - title: ⚙️ Continuous Integrations
+      labels:
+        - '@type/ci'
+
+    - title: 🗑 Revert
+      labels:
+        - '@type/revert'
+
+    - title: 🔍 Other Changes
+      labels:
+        - '*'
+
+    - title: 👒 Dependency Updates
+      labels:
+        - 'dependencies'

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -27,6 +27,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml
           dry-run: ${{ github.event_name == 'pull_request' }}
-          exclude: |
-            help*
-            *issue


### PR DESCRIPTION
## Issue

- close #374 🦕

## 概要

<!-- 概要をここに記入してください。 -->

type ラベルのカイゼンを実施します．

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration for categorizing GitHub release notes based on labels.

- **Chores**
  - Reorganized and refined type labels for better categorization of commits.

- **Documentation**
  - Updated label descriptions to improve clarity on the types of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->