### PR TITLE
feat(home): 直近のクエスト一覧セクションのデザイン実装

### DIFF
--- a/core/data/lib/src/quest_repository.dart
+++ b/core/data/lib/src/quest_repository.dart
@@ -23,7 +23,11 @@ class QuestRepository {
 
   Stream<Quest?> streamById({required QuestId id}) => _dao.streamById(id: id);
 
-  Stream<List<Quest>> allStream() => _dao.allStream();
+  Stream<List<Quest>> stream({
+    int? offset,
+    int? limit,
+  }) =>
+      _dao.stream();
 
   Future<void> insert({required Quest quest}) async =>
       _dao.insert(quest: quest);

--- a/core/database/lib/src/quest/quest_dao.dart
+++ b/core/database/lib/src/quest/quest_dao.dart
@@ -13,7 +13,10 @@ abstract interface class QuestDao {
 
   Stream<Quest?> streamById({required QuestId id});
 
-  Stream<List<Quest>> allStream();
+  Stream<List<Quest>> stream({
+    int? offset,
+    int? limit,
+  });
 
   Future<void> insert({required Quest quest});
 

--- a/core/database_isar/lib/src/quest/isar_quest_dao.dart
+++ b/core/database_isar/lib/src/quest/isar_quest_dao.dart
@@ -36,10 +36,18 @@ final class IsarQuestDao implements QuestDao {
       .map((event) => event.firstOrNull?.asModel());
 
   @override
-  Stream<List<Quest>> allStream() => _isar.quests
-      .where()
-      .watch(fireImmediately: true)
-      .map((event) => event.map((e) => e.asModel()).toList());
+  Stream<List<Quest>> stream({
+    int? offset,
+    int? limit,
+  }) =>
+      _isar.quests
+          .where()
+          .watch(
+            fireImmediately: true,
+            offset: offset,
+            limit: limit,
+          )
+          .map((event) => event.map((e) => e.asModel()).toList());
 
   @override
   Future<void> insert({required Quest quest}) async {

--- a/core/domain/lib/quest_use_case.dart
+++ b/core/domain/lib/quest_use_case.dart
@@ -1,3 +1,4 @@
 export 'src/use_case/quest/add_quest_use_case.dart';
 export 'src/use_case/quest/quest_list_stream_use_case.dart';
 export 'src/use_case/quest/quest_stream_by_id_use_case.dart';
+export 'src/use_case/quest/recent_quest_list_stream_use_case.dart';

--- a/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.dart
+++ b/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.dart
@@ -6,5 +6,7 @@ part 'quest_list_stream_use_case.g.dart';
 
 /// クエスト一覧を取得する ユースケース
 @riverpod
-Stream<List<Quest>> questListStreamUseCase(QuestListStreamUseCaseRef ref) =>
-    ref.watch(questRepositoryProvider).allStream();
+Stream<List<Quest>> questListStreamUseCase(
+  QuestListStreamUseCaseRef ref,
+) =>
+    ref.watch(questRepositoryProvider).stream();

--- a/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/quest_list_stream_use_case.g.dart
@@ -7,7 +7,7 @@ part of 'quest_list_stream_use_case.dart';
 // **************************************************************************
 
 String _$questListStreamUseCaseHash() =>
-    r'3f28b87b625c4b35029b38a228cdeab4e01bedd8';
+    r'db2da4ec480defbb3312c472e9be338332b801ee';
 
 /// クエスト一覧を取得する ユースケース
 ///

--- a/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.dart
+++ b/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.dart
@@ -1,0 +1,12 @@
+import 'package:core_data/repository.dart';
+import 'package:core_model/quest.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recent_quest_list_stream_use_case.g.dart';
+
+/// 直近のクエスト一覧を取得する ユースケース
+@riverpod
+Stream<List<Quest>> recentQuestListStreamUseCase(
+  RecentQuestListStreamUseCaseRef ref,
+) =>
+    ref.watch(questRepositoryProvider).stream(limit: 5);

--- a/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/quest/recent_quest_list_stream_use_case.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recent_quest_list_stream_use_case.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$recentQuestListStreamUseCaseHash() =>
+    r'746c580bd19c2f7a5fed0b0c97e46483ac331023';
+
+/// 直近のクエスト一覧を取得する ユースケース
+///
+/// Copied from [recentQuestListStreamUseCase].
+@ProviderFor(recentQuestListStreamUseCase)
+final recentQuestListStreamUseCaseProvider =
+    AutoDisposeStreamProvider<List<Quest>>.internal(
+  recentQuestListStreamUseCase,
+  name: r'recentQuestListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$recentQuestListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef RecentQuestListStreamUseCaseRef
+    = AutoDisposeStreamProviderRef<List<Quest>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/feature/home/lib/src/ui/page/home/component/recent_quest_list_section.dart
+++ b/feature/home/lib/src/ui/page/home/component/recent_quest_list_section.dart
@@ -1,0 +1,112 @@
+import 'package:core_designsystem/component.dart';
+import 'package:core_domain/quest_use_case.dart';
+import 'package:core_model/quest.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 直近のクエスト一覧を表示するセクション
+final class RecentQuestListSection extends HookConsumerWidget {
+  const RecentQuestListSection({
+    required void Function(Quest quest) onTapQuestListItem,
+    required void Function() onMoreButtonPressed,
+    super.key,
+  })  : _onTapQuestListItem = onTapQuestListItem,
+        _onMoreButtonPressed = onMoreButtonPressed;
+
+  final void Function(Quest quest) _onTapQuestListItem;
+  final VoidCallback _onMoreButtonPressed;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final questList = ref.watch(recentQuestListStreamUseCaseProvider);
+
+    return Container(
+      width: double.infinity,
+      child: Column(
+        children: [
+          const SizedBox(
+            width: double.infinity,
+            child: Text(
+              'Your Quest List',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const Gap(16),
+          questList.when(
+            data: (data) {
+              return SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: data
+                      .map(
+                        (quest) => Container(
+                          width: 150,
+                          height: 150,
+                          decoration: BoxDecoration(
+                            border: Border.all(color: Colors.grey.shade200),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: InkWell(
+                            onTap: () => _onTapQuestListItem(quest),
+                            child: Padding(
+                              padding: const EdgeInsets.all(16),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    quest.name,
+                                    style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  const Gap(8),
+                                  Text(
+                                    quest.description,
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      )
+                      .expand(
+                        (widget) => [
+                          widget,
+                          const Gap(16),
+                        ],
+                      )
+                      .toList(),
+                ),
+              );
+            },
+            error: (error, stackTrace) => Center(
+              child: Text(
+                error.toString(),
+              ),
+            ),
+            loading: () => const Center(
+              child: CircularProgressIndicator(),
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: TextButton(
+                onPressed: _onMoreButtonPressed,
+                child: const Text('More'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/feature/home/lib/src/ui/page/home/home_page.dart
+++ b/feature/home/lib/src/ui/page/home/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:core_designsystem/component.dart';
 import 'package:feature_home/src/ui/page/home/component/quest_overview_section.dart';
+import 'package:feature_home/src/ui/page/home/component/recent_quest_list_section.dart';
 import 'package:flutter/material.dart';
 
 /// ホームページ
@@ -29,8 +30,19 @@ final class HomePage extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              QuestOverviewSection(
-                onQuickAddButtonPressed: () {},
+              ...[
+                QuestOverviewSection(
+                  onQuickAddButtonPressed: () {},
+                ),
+                RecentQuestListSection(
+                  onTapQuestListItem: (quest) {},
+                  onMoreButtonPressed: () {},
+                ),
+              ].expand(
+                (widget) => [
+                  widget,
+                  const Gap(24),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
## Issue

- close #399 🦕

## 概要

<!-- 概要をここに記入してください。 -->

直近のクエスト一覧セクションのデザイン実装を追加します。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/tatsutakein-jp/asis-app/assets/19267812/809120ac-afe6-450a-a087-fe955b69deac" width="300" /> | <img src="https://github.com/tatsutakein-jp/asis-app/assets/19267812/f77135cf-5a6c-444b-a99b-a165433fe0fd" width="300" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 最近のクエストリストを表示する「RecentQuestListSection」ウィジェットを追加。
  - 「RecentQuestListSection」を「HomePage」に追加し、クエストアイテムのタップと追加ロードボタンのイベント処理を対応。

- **改善**
  - クエストのストリーミング機能を改善し、オフセットとリミットのパラメータをサポート。

- **新しいユースケース**
  - 「recentQuestListStreamUseCase」関数を追加し、最新のクエストのストリームを提供。
  
- **その他**
  - 関連するファイルとコードのリファクタリングとハッシュ値の更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->