### PR TITLE
[GH-408]: サービスお知らせのカードコンポーネントを作成する

### DIFF
--- a/core/domain/lib/feed_use_case.dart
+++ b/core/domain/lib/feed_use_case.dart
@@ -1,2 +1,3 @@
 export 'src/use_case/feed/feed_list_stream_use_case.dart';
 export 'src/use_case/feed/feed_stream_by_id_use_case.dart';
+export 'src/use_case/feed/news_feed_list_stream_use_case.dart';

--- a/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.dart
+++ b/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.dart
@@ -1,0 +1,48 @@
+import 'package:core_model/feed.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'news_feed_list_stream_use_case.g.dart';
+
+/// サービスのお知らせ一覧を取得する ユースケース
+@riverpod
+Stream<List<NewsFeed>> newsFeedListStreamUseCase(
+  NewsFeedListStreamUseCaseRef ref,
+) =>
+    Stream.value([
+      const NewsFeed(
+        id: '1',
+        title: 'title',
+        publishedAt: '2024-01-01',
+        excerpt: 'excerpt',
+        coverImageUrl:
+            'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjcyiHSN0IqJybWL_ZOPOVzuyP0Svh2WF8QlSGEGzNjyxuS4Ng7vfHLmnCCRJxac6GOR0wWvwYrkytEVPnzFUM0jgcGW842K6pKasOBfS2qdDkvp69fb2yvLrrsOBeKJYo8Ugppa5Hpf-56/s800/news_gohou.png',
+        content: 'content',
+      ),
+      const NewsFeed(
+        id: '2',
+        title: 'title',
+        publishedAt: '2024-01-02',
+        excerpt: 'excerpt',
+        coverImageUrl:
+            'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjcyiHSN0IqJybWL_ZOPOVzuyP0Svh2WF8QlSGEGzNjyxuS4Ng7vfHLmnCCRJxac6GOR0wWvwYrkytEVPnzFUM0jgcGW842K6pKasOBfS2qdDkvp69fb2yvLrrsOBeKJYo8Ugppa5Hpf-56/s800/news_gohou.png',
+        content: 'content',
+      ),
+      const NewsFeed(
+        id: '3',
+        title: 'title',
+        publishedAt: '2024-01-03',
+        excerpt: 'excerpt',
+        coverImageUrl:
+            'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjcyiHSN0IqJybWL_ZOPOVzuyP0Svh2WF8QlSGEGzNjyxuS4Ng7vfHLmnCCRJxac6GOR0wWvwYrkytEVPnzFUM0jgcGW842K6pKasOBfS2qdDkvp69fb2yvLrrsOBeKJYo8Ugppa5Hpf-56/s800/news_gohou.png',
+        content: 'content',
+      ),
+      const NewsFeed(
+        id: '4',
+        title: 'title',
+        publishedAt: '2024-01-04',
+        excerpt: 'excerpt',
+        coverImageUrl:
+            'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjcyiHSN0IqJybWL_ZOPOVzuyP0Svh2WF8QlSGEGzNjyxuS4Ng7vfHLmnCCRJxac6GOR0wWvwYrkytEVPnzFUM0jgcGW842K6pKasOBfS2qdDkvp69fb2yvLrrsOBeKJYo8Ugppa5Hpf-56/s800/news_gohou.png',
+        content: 'content',
+      ),
+    ]);

--- a/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.g.dart
+++ b/core/domain/lib/src/use_case/feed/news_feed_list_stream_use_case.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'news_feed_list_stream_use_case.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$newsFeedListStreamUseCaseHash() =>
+    r'e34bda64b9f249eb1598f635d7920f132c8e9bb5';
+
+/// サービスのお知らせ一覧を取得する ユースケース
+///
+/// Copied from [newsFeedListStreamUseCase].
+@ProviderFor(newsFeedListStreamUseCase)
+final newsFeedListStreamUseCaseProvider =
+    AutoDisposeStreamProvider<List<NewsFeed>>.internal(
+  newsFeedListStreamUseCase,
+  name: r'newsFeedListStreamUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$newsFeedListStreamUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef NewsFeedListStreamUseCaseRef
+    = AutoDisposeStreamProviderRef<List<NewsFeed>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/core/model/lib/src/feed/index.dart
+++ b/core/model/lib/src/feed/index.dart
@@ -1,1 +1,2 @@
 export 'feed.dart';
+export 'news_feed.dart';

--- a/core/model/lib/src/feed/news_feed.dart
+++ b/core/model/lib/src/feed/news_feed.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'news_feed.freezed.dart';
+
+typedef NewsFeedId = String;
+
+/// サービスのお知らせ
+///
+/// {@category Model}
+@freezed
+class NewsFeed with _$NewsFeed {
+  const factory NewsFeed({
+    required NewsFeedId id,
+    required String title,
+    required String publishedAt,
+    required String excerpt,
+    required String coverImageUrl,
+    required String content,
+  }) = _NewsFeed;
+}

--- a/core/model/lib/src/feed/news_feed.freezed.dart
+++ b/core/model/lib/src/feed/news_feed.freezed.dart
@@ -1,0 +1,238 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'news_feed.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$NewsFeed {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get publishedAt => throw _privateConstructorUsedError;
+  String get excerpt => throw _privateConstructorUsedError;
+  String get coverImageUrl => throw _privateConstructorUsedError;
+  String get content => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $NewsFeedCopyWith<NewsFeed> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NewsFeedCopyWith<$Res> {
+  factory $NewsFeedCopyWith(NewsFeed value, $Res Function(NewsFeed) then) =
+      _$NewsFeedCopyWithImpl<$Res, NewsFeed>;
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String publishedAt,
+      String excerpt,
+      String coverImageUrl,
+      String content});
+}
+
+/// @nodoc
+class _$NewsFeedCopyWithImpl<$Res, $Val extends NewsFeed>
+    implements $NewsFeedCopyWith<$Res> {
+  _$NewsFeedCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = null,
+    Object? content = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      publishedAt: null == publishedAt
+          ? _value.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as String,
+      excerpt: null == excerpt
+          ? _value.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: null == coverImageUrl
+          ? _value.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NewsFeedImplCopyWith<$Res>
+    implements $NewsFeedCopyWith<$Res> {
+  factory _$$NewsFeedImplCopyWith(
+          _$NewsFeedImpl value, $Res Function(_$NewsFeedImpl) then) =
+      __$$NewsFeedImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String publishedAt,
+      String excerpt,
+      String coverImageUrl,
+      String content});
+}
+
+/// @nodoc
+class __$$NewsFeedImplCopyWithImpl<$Res>
+    extends _$NewsFeedCopyWithImpl<$Res, _$NewsFeedImpl>
+    implements _$$NewsFeedImplCopyWith<$Res> {
+  __$$NewsFeedImplCopyWithImpl(
+      _$NewsFeedImpl _value, $Res Function(_$NewsFeedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? publishedAt = null,
+    Object? excerpt = null,
+    Object? coverImageUrl = null,
+    Object? content = null,
+  }) {
+    return _then(_$NewsFeedImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      publishedAt: null == publishedAt
+          ? _value.publishedAt
+          : publishedAt // ignore: cast_nullable_to_non_nullable
+              as String,
+      excerpt: null == excerpt
+          ? _value.excerpt
+          : excerpt // ignore: cast_nullable_to_non_nullable
+              as String,
+      coverImageUrl: null == coverImageUrl
+          ? _value.coverImageUrl
+          : coverImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$NewsFeedImpl implements _NewsFeed {
+  const _$NewsFeedImpl(
+      {required this.id,
+      required this.title,
+      required this.publishedAt,
+      required this.excerpt,
+      required this.coverImageUrl,
+      required this.content});
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String publishedAt;
+  @override
+  final String excerpt;
+  @override
+  final String coverImageUrl;
+  @override
+  final String content;
+
+  @override
+  String toString() {
+    return 'NewsFeed(id: $id, title: $title, publishedAt: $publishedAt, excerpt: $excerpt, coverImageUrl: $coverImageUrl, content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NewsFeedImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.publishedAt, publishedAt) ||
+                other.publishedAt == publishedAt) &&
+            (identical(other.excerpt, excerpt) || other.excerpt == excerpt) &&
+            (identical(other.coverImageUrl, coverImageUrl) ||
+                other.coverImageUrl == coverImageUrl) &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, title, publishedAt, excerpt, coverImageUrl, content);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NewsFeedImplCopyWith<_$NewsFeedImpl> get copyWith =>
+      __$$NewsFeedImplCopyWithImpl<_$NewsFeedImpl>(this, _$identity);
+}
+
+abstract class _NewsFeed implements NewsFeed {
+  const factory _NewsFeed(
+      {required final String id,
+      required final String title,
+      required final String publishedAt,
+      required final String excerpt,
+      required final String coverImageUrl,
+      required final String content}) = _$NewsFeedImpl;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get publishedAt;
+  @override
+  String get excerpt;
+  @override
+  String get coverImageUrl;
+  @override
+  String get content;
+  @override
+  @JsonKey(ignore: true)
+  _$$NewsFeedImplCopyWith<_$NewsFeedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/feature/feed/lib/src/ui/page/list/component/news_feed_card_section.dart
+++ b/feature/feed/lib/src/ui/page/list/component/news_feed_card_section.dart
@@ -1,0 +1,118 @@
+import 'package:core_designsystem/component.dart';
+import 'package:core_domain/feed_use_case.dart';
+import 'package:core_model/feed.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final class NewsFeedCardSection extends ConsumerWidget {
+  const NewsFeedCardSection({
+    required void Function(NewsFeed newsFeed) onTap,
+    super.key,
+  }) : _onTap = onTap;
+
+  final void Function(NewsFeed newsFeed) _onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(newsFeedListStreamUseCaseProvider).when(
+          data: (data) {
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.all(16),
+              // FIX: データ 3 個目以降に MORE を表示したい
+              child: Row(
+                children: data
+                    .map(
+                      (news) => InkWell(
+                        borderRadius: BorderRadius.circular(8),
+                        onTap: () => _onTap(news),
+                        // MEMO: RadiusInkWell みたいに作ると便利かも
+                        child: Container(
+                          padding: const EdgeInsets.all(8),
+                          // MEMO: ここを固定とするかは要検討
+                          height: 120,
+                          decoration: BoxDecoration(
+                            border: Border.all(color: Colors.grey.shade200),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          // MEMO: Container.height を元に比率でカードサイズを確定
+                          child: AspectRatio(
+                            aspectRatio: 16 / 9,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              // MEMO: タイトルと内容の比率は一旦 3:4
+                              children: [
+                                Expanded(
+                                  flex: 3,
+                                  child: Row(
+                                    // MEMO: アイコンとタイトルの比率は一旦 1:4
+                                    children: [
+                                      Expanded(
+                                        child: DecoratedBox(
+                                          decoration: BoxDecoration(
+                                            border: Border.all(
+                                              color: Colors.grey.shade200,
+                                            ),
+                                            borderRadius:
+                                                BorderRadius.circular(50),
+                                          ),
+                                          child: Image.network(
+                                            news.coverImageUrl,
+                                            fit: BoxFit.contain,
+                                          ),
+                                        ),
+                                      ),
+                                      const Gap(8),
+                                      Expanded(
+                                        flex: 4,
+                                        child: Text(
+                                          news.title,
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .titleMedium,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                const Gap(8),
+                                Expanded(
+                                  flex: 4,
+                                  child: Text(
+                                    news.excerpt,
+                                    style:
+                                        Theme.of(context).textTheme.bodyMedium,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    )
+                    .expand(
+                      (widget) => [
+                        widget,
+                        const Gap(16),
+                      ],
+                    )
+                    .toList(),
+              ),
+            );
+          },
+          // MEMO: 一旦、書いただけ
+          error: (error, stackTrace) => Center(
+            child: Text(
+              error.toString(),
+            ),
+          ),
+          // MEMO: 一旦、書いただけ
+          loading: () => const Center(
+            child: CircularProgressIndicator(),
+          ),
+        );
+  }
+}


### PR DESCRIPTION
## Issue

- close #408 

## 概要

<!-- 概要をここに記入してください。 -->

- 運営からのお知らせを表示するカードを作成しました。
- モデルおよびユースケースの作成を行いました。

## レビュー観点

- ユースケースに関しては一旦ダミーデータをベタ書きで返しています（URLについてはいらすと屋にしています）
- カードについては３枚まで表示後、MOREなどにしたかったですが、一旦ステイしています。というのも、Feature側で判断させるのか、それとも最初からカードで表示するためのデータを3つまでしか取らないユースケースを用意するかで実装方法も変わるからです。
- 描写されてるのが見たい場合、FeedとWidgetを入れ替えて確認してみてください。

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           オーバーフロー時はこんな感じ           |
|:--------------------------:|
| <img src="https://github.com/tatsutakein-jp/asis-app/assets/54802496/b8086ee6-7377-43fe-9a7c-1623d004b8a1" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- ニュースフィードのストリームを取得する機能を追加しました。
	- 水平スクロール可能なカードでニュースフィード項目を表示するウィジェット「NewsFeedCardSection」を追加しました。

- **改良**
	- ニュースフィードデータモデルを追加し、フィールドとしてID、タイトル、公開日時、抜粋、カバー画像URL、コンテンツを含むようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->