### PR TITLE
feat(app): envied を導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@
 # Files and directories created by pub
 .dart_tool/
 
-# dotenv environment variables file
-.env*
-
 # melos
 pubspec_overrides.yaml
 

--- a/app/.env.sample
+++ b/app/.env.sample
@@ -1,0 +1,2 @@
+# .env
+KEY=SAMPLE

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -45,3 +45,8 @@ app.*.map.json
 # firebase
 lib/flavor/stg/firebase_options.dart
 lib/flavor/prod/firebase_options.dart
+
+# dotenv environment variables file
+/.env*
+!/.env.sample
+/lib/env.g.dart

--- a/app/lib/env.dart
+++ b/app/lib/env.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: avoid_classes_with_only_static_members
+
+import 'package:envied/envied.dart';
+
+part 'env.g.dart';
+
+@Envied(obfuscate: true, requireEnvFile: true, path: '.env')
+abstract class Env {
+  @EnviedField(varName: 'KEY', obfuscate: true)
+  static final String key = _Env.key;
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -313,6 +313,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
+  envied:
+    dependency: "direct main"
+    description:
+      name: envied
+      sha256: bbff9c76120e4dc5e2e36a46690cf0a26feb65e7765633f4e8d916bcd173a450
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
+  envied_generator:
+    dependency: "direct dev"
+    description:
+      name: envied_generator
+      sha256: "517b70de08d13dcd40e97b4e5347e216a0b1c75c99e704f3c85c0474a392d14a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -832,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   riverpod:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
     path: ../core/ui
   cupertino_icons: 1.0.8
   dynamic_color: 1.7.0
+  envied: 0.5.4+1
   feature_auth:
     # noinspection DartPathPackageReference
     path: ../feature/auth
@@ -83,6 +84,7 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: 2.4.11
+  envied_generator: 0.5.4+1
   flutter_test:
     sdk: flutter
   go_router_builder: 2.7.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,6 +12,11 @@ ide:
   intellij:
     enabled: false
 
+command:
+  bootstrap:
+    hooks:
+      post: melos run gen:app
+
 scripts:
   # analyze
   analyze:
@@ -36,6 +41,11 @@ scripts:
     description: Run build_runner.
     packageFilters:
       dependsOn: "build_runner"
+  gen:app:
+    run: |
+      melos exec --scope="app" \
+        dart run build_runner build --delete-conflicting-outputs
+    description: Run build_runner.
   gen:l10n:
     run: flutter gen-l10n
     exec:

--- a/tool/gen_gitignore_files.sh
+++ b/tool/gen_gitignore_files.sh
@@ -47,6 +47,34 @@ fi
 
 ##############################################################################
 ##
+##  Env
+##
+##############################################################################
+echo ""
+echo "🚀 Env: Start"
+
+# source file (sample)
+ENV_SOURCE_FILE="app/.env.sample"
+
+# copy
+ENV_TARGET="app/.env"
+cp -i "$ENV_SOURCE_FILE" "$ENV_TARGET"
+ENV_COPY_TO_TARGET=$?
+if [ $ENV_COPY_TO_TARGET -eq 0 ]; then
+    echo "🎉 Env: Successfully generated $ENV_TARGET"
+else
+    echo "⚠️ Env: Failed to generate $ENV_TARGET"
+fi
+
+# result
+if [ $ENV_COPY_TO_TARGET -eq 0 ]; then
+  echo "✅ Env: Success"
+else
+  echo "🚫 Env: Failed"
+fi
+
+##############################################################################
+##
 ##  Finish
 ##
 ##############################################################################


### PR DESCRIPTION
## Issue

- close #415 🦕

## 概要

<!-- 概要をここに記入してください。 -->

envied を導入します。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://github.com/petercinibulk/envied

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 環境設定のサンプルファイル `.env.sample` を追加。
  - `env.dart` で `Env` クラスを導入し、環境変数の扱いを簡素化。
  
- **ドキュメント**
  - `.gitignore` の更新により、`.env*` ファイルの除外を解除。
  - `app/.gitignore` に `.env.sample` と `/lib/env.g.dart` の除外を追加。

- **依存関係**
  - `pubspec.yaml` に `envied` および `envied_generator` パッケージを追加。

- **チョア**
  - `melos.yaml` に新しいコマンド `gen:app` を追加し、環境ファイルの生成を自動化。
  - 環境ファイル管理用のスクリプト `tool/gen_gitignore_files.sh` を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->