### PR TITLE
refactor: typedef を利用してクラス名の競合を解消

### DIFF
--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -1,4 +1,5 @@
 import 'package:app/gen/l10n/l10n.dart';
+import 'package:core_designsystem/l10n.dart';
 import 'package:core_ui/l10n.dart';
 import 'package:feature_auth/feature_auth.dart';
 import 'package:feature_feed/feature_feed.dart';
@@ -8,6 +9,7 @@ import 'package:feature_settings/feature_settings.dart';
 
 const appLocalizationsDelegates = [
   ...L10n.localizationsDelegates,
+  ...CoreDesignSystemL10n.localizationsDelegates,
   ...CoreUiL10n.localizationsDelegates,
   ...FeatureAuthL10n.localizationsDelegates,
   ...FeatureFeedL10n.localizationsDelegates,
@@ -18,6 +20,7 @@ const appLocalizationsDelegates = [
 
 const appSupportedLocales = [
   ...L10n.supportedLocales,
+  ...CoreDesignSystemL10n.supportedLocales,
   ...CoreUiL10n.supportedLocales,
   ...FeatureAuthL10n.supportedLocales,
   ...FeatureFeedL10n.supportedLocales,

--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -1,27 +1,27 @@
 import 'package:app/gen/l10n/l10n.dart';
-import 'package:core_ui/l10n.dart' as core_ui;
-import 'package:feature_auth/feature_auth.dart' as feature_auth;
-import 'package:feature_feed/feature_feed.dart' as feature_feed;
-import 'package:feature_home/feature_home.dart' as feature_home;
-import 'package:feature_quest/feature_quest.dart' as feature_quest;
-import 'package:feature_settings/feature_settings.dart' as feature_settings;
+import 'package:core_ui/l10n.dart';
+import 'package:feature_auth/feature_auth.dart';
+import 'package:feature_feed/feature_feed.dart';
+import 'package:feature_home/feature_home.dart';
+import 'package:feature_quest/feature_quest.dart';
+import 'package:feature_settings/feature_settings.dart';
 
 const appLocalizationsDelegates = [
   ...L10n.localizationsDelegates,
-  ...core_ui.L10n.localizationsDelegates,
-  ...feature_auth.L10n.localizationsDelegates,
-  ...feature_feed.L10n.localizationsDelegates,
-  ...feature_home.L10n.localizationsDelegates,
-  ...feature_quest.L10n.localizationsDelegates,
-  ...feature_settings.L10n.localizationsDelegates,
+  ...CoreUiL10n.localizationsDelegates,
+  ...FeatureAuthL10n.localizationsDelegates,
+  ...FeatureFeedL10n.localizationsDelegates,
+  ...FeatureHomeL10n.localizationsDelegates,
+  ...FeatureQuestL10n.localizationsDelegates,
+  ...FeatureSettingsL10n.localizationsDelegates,
 ];
 
 const appSupportedLocales = [
   ...L10n.supportedLocales,
-  ...core_ui.L10n.supportedLocales,
-  ...feature_auth.L10n.supportedLocales,
-  ...feature_feed.L10n.supportedLocales,
-  ...feature_home.L10n.supportedLocales,
-  ...feature_quest.L10n.supportedLocales,
-  ...feature_settings.L10n.supportedLocales,
+  ...CoreUiL10n.supportedLocales,
+  ...FeatureAuthL10n.supportedLocales,
+  ...FeatureFeedL10n.supportedLocales,
+  ...FeatureHomeL10n.supportedLocales,
+  ...FeatureQuestL10n.supportedLocales,
+  ...FeatureSettingsL10n.supportedLocales,
 ];

--- a/core/designsystem/l10n.yaml
+++ b/core/designsystem/l10n.yaml
@@ -1,0 +1,12 @@
+arb-dir: lib/src/l10n
+output-dir: lib/src/gen/l10n
+template-arb-file: app_ja.arb
+output-localization-file: l10n.dart
+output-class: L10n
+synthetic-package: false
+preferred-supported-locales:
+  - ja
+  - en
+header: '// ignore_for_file: type=lint'
+nullable-getter: false
+format: true

--- a/core/designsystem/lib/l10n.dart
+++ b/core/designsystem/lib/l10n.dart
@@ -1,0 +1,3 @@
+import 'package:core_designsystem/src/gen/l10n/l10n.dart';
+
+typedef CoreDesignSystemL10n = L10n;

--- a/core/designsystem/lib/src/gen/l10n/l10n.dart
+++ b/core/designsystem/lib/src/gen/l10n/l10n.dart
@@ -1,0 +1,136 @@
+// ignore_for_file: type=lint
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'l10n_en.dart';
+import 'l10n_ja.dart';
+
+/// Callers can lookup localized strings with an instance of L10n
+/// returned by `L10n.of(context)`.
+///
+/// Applications need to include `L10n.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/l10n.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: L10n.localizationsDelegates,
+///   supportedLocales: L10n.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the L10n.supportedLocales
+/// property.
+abstract class L10n {
+  L10n(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static L10n of(BuildContext context) {
+    return Localizations.of<L10n>(context, L10n)!;
+  }
+
+  static const LocalizationsDelegate<L10n> delegate = _L10nDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('ja'),
+    Locale('en')
+  ];
+
+  /// No description provided for @designsystemText.
+  ///
+  /// In ja, this message translates to:
+  /// **'テキスト'**
+  String get designsystemText;
+}
+
+class _L10nDelegate extends LocalizationsDelegate<L10n> {
+  const _L10nDelegate();
+
+  @override
+  Future<L10n> load(Locale locale) {
+    return SynchronousFuture<L10n>(lookupL10n(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_L10nDelegate old) => false;
+}
+
+L10n lookupL10n(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return L10nEn();
+    case 'ja':
+      return L10nJa();
+  }
+
+  throw FlutterError(
+      'L10n.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
+}

--- a/core/designsystem/lib/src/gen/l10n/l10n_en.dart
+++ b/core/designsystem/lib/src/gen/l10n/l10n_en.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: type=lint
+
+import 'l10n.dart';
+
+/// The translations for English (`en`).
+class L10nEn extends L10n {
+  L10nEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get designsystemText => 'Text';
+}

--- a/core/designsystem/lib/src/gen/l10n/l10n_ja.dart
+++ b/core/designsystem/lib/src/gen/l10n/l10n_ja.dart
@@ -1,0 +1,11 @@
+// ignore_for_file: type=lint
+
+import 'l10n.dart';
+
+/// The translations for Japanese (`ja`).
+class L10nJa extends L10n {
+  L10nJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get designsystemText => 'テキスト';
+}

--- a/core/designsystem/lib/src/l10n/app_en.arb
+++ b/core/designsystem/lib/src/l10n/app_en.arb
@@ -1,0 +1,3 @@
+{
+  "designsystemText": "Text"
+}

--- a/core/designsystem/lib/src/l10n/app_ja.arb
+++ b/core/designsystem/lib/src/l10n/app_ja.arb
@@ -1,0 +1,3 @@
+{
+  "designsystemText": "テキスト"
+}

--- a/core/designsystem/pubspec.lock
+++ b/core/designsystem/pubspec.lock
@@ -99,6 +99,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.11"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -120,6 +125,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   json_annotation:
     dependency: transitive
     description:

--- a/core/designsystem/pubspec.yaml
+++ b/core/designsystem/pubspec.yaml
@@ -13,7 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_adaptive_scaffold: 0.1.11
+  flutter_localizations:
+    sdk: flutter
   gap: 3.0.1
+  intl: 0.19.0
 
 dev_dependencies:
   core_testing:

--- a/core/ui/lib/l10n.dart
+++ b/core/ui/lib/l10n.dart
@@ -1,1 +1,3 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:core_ui/src/gen/l10n/l10n.dart';
+
+typedef CoreUiL10n = L10n;

--- a/feature/auth/lib/feature_auth.dart
+++ b/feature/auth/lib/feature_auth.dart
@@ -1,2 +1,5 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:feature_auth/src/gen/l10n/l10n.dart';
+
 export 'src/ui/page/auth/auth_page.dart';
+
+typedef FeatureAuthL10n = L10n;

--- a/feature/feed/lib/feature_feed.dart
+++ b/feature/feed/lib/feature_feed.dart
@@ -1,3 +1,6 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:feature_feed/src/gen/l10n/l10n.dart';
+
 export 'src/ui/page/detail/feed_detail_page.dart';
 export 'src/ui/page/list/feed_list_page.dart';
+
+typedef FeatureFeedL10n = L10n;

--- a/feature/home/lib/feature_home.dart
+++ b/feature/home/lib/feature_home.dart
@@ -1,2 +1,5 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:feature_home/src/gen/l10n/l10n.dart';
+
 export 'src/ui/page/home/home_page.dart';
+
+typedef FeatureHomeL10n = L10n;

--- a/feature/quest/lib/feature_quest.dart
+++ b/feature/quest/lib/feature_quest.dart
@@ -1,4 +1,7 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:feature_quest/src/gen/l10n/l10n.dart';
+
 export 'src/ui/page/add/quest_add_page.dart';
 export 'src/ui/page/detail/quest_detail_page.dart';
 export 'src/ui/page/list/quest_list_page.dart';
+
+typedef FeatureQuestL10n = L10n;

--- a/feature/settings/lib/feature_settings.dart
+++ b/feature/settings/lib/feature_settings.dart
@@ -1,3 +1,6 @@
-export 'src/gen/l10n/l10n.dart';
+import 'package:feature_settings/src/gen/l10n/l10n.dart';
+
 export 'src/ui/page/settings/settings_page.dart';
 export 'src/ui/page/settings/theme_setting_dialog_page.dart';
+
+typedef FeatureSettingsL10n = L10n;


### PR DESCRIPTION
## Issue

- close #418 🦕

## 概要

<!-- 概要をここに記入してください。 -->

typedef を利用してクラス名の競合を解消します。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 日本語と英語のローカリゼーションをサポートするための新しいローカライゼーション機能を導入しました。
  
- **バグ修正**
  - アプリ全体のローカリゼーション機能に関するいくつかの修正を行いました。

- **ドキュメンテーション**
  - ドキュメントに、サポートされているローカリゼーションの詳細を追加しました。

- **リファクタリング**
  - ローカリゼーションパッケージのインポートステートメントを更新し、さまざまなモジュールのローカリゼーションデリゲートとサポートされているロケールの参照を統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->