### PR TITLE
[Improve]: ニュースカードへタップアクションの追加 / 全部見るボタンの追加

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1186,6 +1186,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
   - video_player_avfoundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -1200,6 +1202,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 SPEC REPOS:
@@ -1246,6 +1249,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
   video_player_avfoundation:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
@@ -1281,6 +1286,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
 
 PODFILE CHECKSUM: 6150a9e74fbdb1f914e34d1010fcbe9acdaf34db

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -373,7 +373,7 @@
 				};
 			};
 			buildConfigurationList = 97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 15.0";
+			compatibilityVersion = "Xcode 15.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/app/ios/Runner/Dev/Info.plist
+++ b/app/ios/Runner/Dev/Info.plist
@@ -45,5 +45,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>http</string>
+        <string>https</string>
+    </array>
 </dict>
 </plist>

--- a/app/ios/Runner/Prod/Info.plist
+++ b/app/ios/Runner/Prod/Info.plist
@@ -45,5 +45,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>http</string>
+        <string>https</string>
+    </array>
 </dict>
 </plist>

--- a/app/ios/Runner/Stg/Info.plist
+++ b/app/ios/Runner/Stg/Info.plist
@@ -45,5 +45,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>http</string>
+        <string>https</string>
+    </array>
 </dict>
 </plist>

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -1,7 +1,9 @@
+import 'package:app/initializer/app_config_initializer.dart';
 import 'package:app/router/app_navigation_bar.dart';
 import 'package:app/router/app_navigation_key.dart';
 import 'package:app/router/app_page_path.dart';
 import 'package:core_authenticator/authenticator.dart';
+import 'package:core_model/app_config.dart';
 import 'package:core_model/auth.dart';
 import 'package:core_model/feed.dart';
 import 'package:core_model/quest.dart';
@@ -12,27 +14,20 @@ import 'package:feature_quest/feature_quest.dart';
 import 'package:feature_settings/feature_settings.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'app_router.g.dart';
-
 part 'package:app/router/routes/app_shell_route.dart';
-
 part 'package:app/router/routes/auth_route.dart';
-
 part 'package:app/router/routes/feed_route.dart';
-
 part 'package:app/router/routes/home_route.dart';
-
 part 'package:app/router/routes/quest_route.dart';
-
 part 'package:app/router/routes/settings_route.dart';
-
 part 'package:app/router/shell_branch/home_branch.dart';
-
 part 'package:app/router/shell_branch/quest_branch.dart';
-
 part 'package:app/router/shell_branch/settings_branch.dart';
 
 /// ルートナビゲーターのキー

--- a/app/lib/router/routes/feed_route.dart
+++ b/app/lib/router/routes/feed_route.dart
@@ -11,6 +11,8 @@ final class FeedListRoute extends GoRouteData {
         onTapFeedListItem: (feed) {
           FeedDetailRoute(feedId: feed.id).go(context);
         },
+        onTapNewsFeedCardItem: (newsFeed) {},
+        onTapMoreNewsFeed: () {},
       );
 }
 

--- a/app/lib/router/routes/feed_route.dart
+++ b/app/lib/router/routes/feed_route.dart
@@ -11,7 +11,18 @@ final class FeedListRoute extends GoRouteData {
         onTapFeedListItem: (feed) {
           FeedDetailRoute(feedId: feed.id).go(context);
         },
-        onTapNewsFeedCardItem: (newsFeed) {},
+        onTapNewsFeedCardItem: (newsFeed) async {
+          final appConfig = await initializeAppConfig();
+
+          final websiteUrl = ProviderContainer(
+            overrides: [
+              appConfigProvider.overrideWithValue(appConfig),
+            ],
+          ).read(appConfigProvider.select((config) => config.websiteUrl));
+
+          final uri = Uri.parse('$websiteUrl/news/${newsFeed.slug}');
+          await launchUrl(uri, mode: LaunchMode.inAppWebView);
+        },
         onTapMoreNewsFeed: () {},
       );
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1291,6 +1291,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   vector_graphics:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   path_provider: 2.1.3
   riverpod_annotation: 2.3.5
   shared_preferences: 2.2.3
+  url_launcher: 6.3.0
 
 dependency_overrides:
   # workaround

--- a/feature/feed/lib/src/ui/page/list/component/news_feed_card_section.dart
+++ b/feature/feed/lib/src/ui/page/list/component/news_feed_card_section.dart
@@ -6,11 +6,15 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final class NewsFeedCardSection extends ConsumerWidget {
   const NewsFeedCardSection({
-    required void Function(NewsFeed newsFeed) onTap,
+    required void Function(NewsFeed newsFeed) onTapNewsFeedCardItem,
+    required void Function() onTapMoreNewsFeed,
     super.key,
-  }) : _onTap = onTap;
+  })  : _onTapNewsFeedCardItem = onTapNewsFeedCardItem,
+        _onTapMoreNewsFeed = onTapMoreNewsFeed;
 
-  final void Function(NewsFeed newsFeed) _onTap;
+  final void Function(NewsFeed newsFeed) _onTapNewsFeedCardItem;
+  final void Function() _onTapMoreNewsFeed;
+  static const _displayDataCounts = 3;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -19,92 +23,107 @@ final class NewsFeedCardSection extends ConsumerWidget {
             return SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               padding: const EdgeInsets.all(16),
-              // FIX: データ 3 個目以降に MORE を表示したい
               child: Row(
-                children: data
-                    .map(
-                      (news) => InkWell(
-                        borderRadius: BorderRadius.circular(8),
-                        onTap: () => _onTap(news),
-                        // MEMO: RadiusInkWell みたいに作ると便利かも
-                        child: Container(
-                          padding: const EdgeInsets.all(8),
-                          // MEMO: ここを固定とするかは要検討
-                          height: 120,
-                          decoration: BoxDecoration(
-                            border: Border.all(color: Colors.grey.shade200),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          // MEMO: Container.height を元に比率でカードサイズを確定
-                          child: AspectRatio(
-                            aspectRatio: 16 / 9,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              // MEMO: タイトルと内容の比率は一旦 3:4
-                              children: [
-                                Expanded(
-                                  flex: 3,
-                                  child: Row(
-                                    // MEMO: アイコンとタイトルの比率は一旦 1:4
-                                    children: [
-                                      Expanded(
-                                        child: DecoratedBox(
-                                          decoration: BoxDecoration(
-                                            border: Border.all(
-                                              color: Colors.grey.shade200,
+                children: [
+                  ...data
+                      .take(_displayDataCounts)
+                      .map(
+                        (news) => InkWell(
+                          borderRadius: BorderRadius.circular(8),
+                          onTap: () => _onTapNewsFeedCardItem(news),
+                          // MEMO: RadiusInkWell みたいに作ると便利かも
+                          child: Container(
+                            padding: const EdgeInsets.all(8),
+                            // MEMO: ここを固定とするかは要検討
+                            height: 120,
+                            decoration: BoxDecoration(
+                              border: Border.all(color: Colors.grey.shade200),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            // MEMO: Container.height を元に比率でカードサイズを確定
+                            child: AspectRatio(
+                              aspectRatio: 16 / 9,
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                // MEMO: タイトルと内容の比率は一旦 3:4
+                                children: [
+                                  Expanded(
+                                    flex: 3,
+                                    child: Row(
+                                      // MEMO: アイコンとタイトルの比率は一旦 1:4
+                                      children: [
+                                        Expanded(
+                                          child: DecoratedBox(
+                                            decoration: BoxDecoration(
+                                              border: Border.all(
+                                                color: Colors.grey.shade200,
+                                              ),
+                                              shape: BoxShape.circle,
                                             ),
-                                            borderRadius:
-                                                BorderRadius.circular(50),
+                                            child: news.coverImageUrl != null
+                                                ? Image.network(
+                                                    news.coverImageUrl!,
+                                                    fit: BoxFit.cover,
+                                                  )
+                                                : const BrandIcon(
+                                                    width: 40,
+                                                    height: 40,
+                                                  ),
                                           ),
-                                          child: news.coverImageUrl != null
-                                              ? Image.network(
-                                                  news.coverImageUrl!,
-                                                  fit: BoxFit.cover,
-                                                )
-                                              : const BrandIcon(
-                                                  width: 40,
-                                                  height: 40,
-                                                ),
                                         ),
-                                      ),
-                                      const Gap(8),
-                                      Expanded(
-                                        flex: 4,
-                                        child: Text(
-                                          news.title,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .titleMedium,
-                                          overflow: TextOverflow.ellipsis,
+                                        const Gap(8),
+                                        Expanded(
+                                          flex: 4,
+                                          child: Text(
+                                            news.title,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleMedium,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
                                         ),
-                                      ),
-                                    ],
+                                      ],
+                                    ),
                                   ),
-                                ),
-                                const Gap(8),
-                                Expanded(
-                                  flex: 4,
-                                  child: Text(
-                                    news.excerpt,
-                                    style:
-                                        Theme.of(context).textTheme.bodyMedium,
-                                    maxLines: 2,
-                                    overflow: TextOverflow.ellipsis,
+                                  const Gap(8),
+                                  Expanded(
+                                    flex: 4,
+                                    child: Text(
+                                      news.excerpt,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodyMedium,
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
                                   ),
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
                           ),
                         ),
+                      )
+                      .expand(
+                        (widget) => [
+                          widget,
+                          const Gap(16),
+                        ],
                       ),
-                    )
-                    .expand(
-                      (widget) => [
-                        widget,
-                        const Gap(16),
-                      ],
-                    )
-                    .toList(),
+                  Visibility(
+                    visible: data.length > _displayDataCounts,
+                    child: IconButton(
+                      icon: const Icon(Icons.arrow_forward_ios),
+                      style: ElevatedButton.styleFrom(
+                        shape: CircleBorder(
+                          side: BorderSide(
+                            color: Colors.grey.shade200,
+                          ),
+                        ),
+                      ),
+                      onPressed: _onTapMoreNewsFeed,
+                    ),
+                  ),
+                ],
               ),
             );
           },

--- a/feature/feed/lib/src/ui/page/list/feed_list_page.dart
+++ b/feature/feed/lib/src/ui/page/list/feed_list_page.dart
@@ -9,10 +9,16 @@ import 'package:flutter/material.dart';
 final class FeedListPage extends StatelessWidget {
   const FeedListPage({
     required void Function(Feed) onTapFeedListItem,
+    required void Function(NewsFeed) onTapNewsFeedCardItem,
+    required void Function() onTapMoreNewsFeed,
     super.key,
-  }) : _onTapFeedListItem = onTapFeedListItem;
+  })  : _onTapFeedListItem = onTapFeedListItem,
+        _onTapNewsFeedCardItem = onTapNewsFeedCardItem,
+        _onTapMoreNewsFeed = onTapMoreNewsFeed;
 
   final void Function(Feed feed) _onTapFeedListItem;
+  final void Function(NewsFeed newsFeed) _onTapNewsFeedCardItem;
+  final void Function() _onTapMoreNewsFeed;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +32,8 @@ final class FeedListPage extends StatelessWidget {
         child: Column(
           children: [
             NewsFeedCardSection(
-              onTap: (_) {},
+              onTapNewsFeedCardItem: _onTapNewsFeedCardItem,
+              onTapMoreNewsFeed: _onTapMoreNewsFeed,
             ),
             FeedList(
               onTapFeedListItem: _onTapFeedListItem,


### PR DESCRIPTION
## 概要

<!-- 概要をここに記入してください。 -->

- ニュースカードのタップ時に url_launcher で webview 表示するようにしました
- データが3個以上のときに全て表示するボタンを追加しました（遷移先はこれから）

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

- `app/lib/router/routes/feed_route.dart` で appConfig を使うために無茶苦茶しているので、いい方法があれば！

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           iOS           |           Android            |
|:--------------------------:|:--------------------------:|
| <video src="https://github.com/tatsutakein-jp/asis-app/assets/54802496/8251a86f-87f6-408c-9658-a69a01738325" width="300" /> | <video src="https://github.com/tatsutakein-jp/asis-app/assets/54802496/40ae1c50-3566-45b6-8d42-4f2b6e6e5d77" width="300" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - iOSアプリで外部URLスキーム（httpおよびhttps）を問い合わせできるようにInfo.plistファイルを更新しました。

- **依存関係の更新**
  - `url_launcher`依存関係を追加しました（バージョン6.3.0）。

- **機能改善**
  - フィードリストページとニュースフィードカードセクションに新しいタップ機能を追加しました。例えば、ニュースフィード項目をタップした際の処理や、さらに多くのニュースフィードを表示するための機能などが含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->